### PR TITLE
Reference correct source file and name in diagnostics in imported avdl files

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -330,7 +330,7 @@ impl Idl {
 
             let span_len = source.len().min(1);
             return Err(ParseDiagnostic {
-                src: SpanWithSource::new(0, span_len, source_name, source),
+                span: SpanWithSource::new(0, span_len, source_name, source),
                 message: "IDL file contains neither a protocol nor a schema declaration"
                     .to_string(),
                 label: Some("this file".to_string()),
@@ -676,9 +676,9 @@ fn process_decl_items(
             }
             DeclItem::Type(schema, span, field_spans) => {
                 if let Err(msg) = ctx.registry.register(schema.as_ref().clone()) {
-                    if let Some(sws) = span.as_ref() {
+                    if let Some(span) = span.as_ref() {
                         return Err(ParseDiagnostic {
-                            src: sws.clone(),
+                            span: *span,
                             message: msg,
                             label: None,
                             help: None,
@@ -709,12 +709,9 @@ fn process_decl_items(
                         let msg = format!(
                             "Invalid default for field `{field_name}` in `{type_name}`: {reason}"
                         );
-                        let effective_sws = field_spans
-                            .get(&field_name)
-                            .cloned()
-                            .or_else(|| span.clone());
-                        effective_sws.map(|sws| ParseDiagnostic {
-                            src: sws,
+                        let effective_span = field_spans.get(&field_name).copied().or(*span);
+                        effective_span.map(|span| ParseDiagnostic {
+                            span,
                             message: msg,
                             label: None,
                             help: None,
@@ -729,13 +726,10 @@ fn process_decl_items(
                 // Prefer the per-field span (from the variable declaration)
                 // over the type-level span (from the record keyword), so the
                 // diagnostic highlights the offending field, not the record.
-                let effective_sws = field_spans
-                    .get(&first_field)
-                    .cloned()
-                    .or_else(|| span.clone());
-                if let Some(sws) = effective_sws {
+                let effective_span = field_spans.get(&first_field).copied().or(*span);
+                if let Some(span) = effective_span {
                     return Err(ParseDiagnostic {
-                        src: sws,
+                        span,
                         message: first_msg,
                         label: None,
                         help: None,
@@ -761,9 +755,9 @@ fn resolve_single_import(
     let resolved_path = match ctx.import_ctx.resolve_import(&import.path, current_dir) {
         Ok(p) => p,
         Err(e) => {
-            if let Some(sws) = import.span.clone() {
+            if let Some(span) = import.span {
                 return Err(ParseDiagnostic {
-                    src: sws,
+                    span,
                     message: format!("{e}"),
                     label: None,
                     help: None,
@@ -787,25 +781,23 @@ fn resolve_single_import(
 
     match import.kind {
         ImportKind::Protocol => {
-            let imported_messages =
-                import_protocol(&resolved_path, &mut ctx.registry).map_err(|e| {
-                    wrap_import_error(e, import.span.clone(), &resolved_path, "protocol")
-                })?;
+            let imported_messages = import_protocol(&resolved_path, &mut ctx.registry)
+                .map_err(|e| wrap_import_error(e, import.span, &resolved_path, "protocol"))?;
             ctx.messages.extend(imported_messages);
 
             // Track the import so unresolved references from this .avpr can
             // be attributed to the import statement in error diagnostics.
             ctx.json_import_spans
-                .push((resolved_path.display().to_string(), import.span.clone()));
+                .push((resolved_path.display().to_string(), import.span));
         }
         ImportKind::Schema => {
             import_schema(&resolved_path, &mut ctx.registry)
-                .map_err(|e| wrap_import_error(e, import.span.clone(), &resolved_path, "schema"))?;
+                .map_err(|e| wrap_import_error(e, import.span, &resolved_path, "schema"))?;
 
             // Track the import so unresolved references from this .avsc can
             // be attributed to the import statement in error diagnostics.
             ctx.json_import_spans
-                .push((resolved_path.display().to_string(), import.span.clone()));
+                .push((resolved_path.display().to_string(), import.span));
         }
         ImportKind::Idl => {
             let imported_source = fs::read_to_string(&resolved_path)
@@ -861,9 +853,9 @@ fn wrap_import_error(
     resolved_path: &Path,
     kind: &str,
 ) -> miette::Report {
-    if let Some(sws) = span {
+    if let Some(span) = span {
         let diag = ParseDiagnostic {
-            src: sws,
+            span,
             message: format!("import {} {}", kind, resolved_path.display()),
             label: None,
             help: None,
@@ -1056,7 +1048,7 @@ fn validate_all_references(
     // first. References without a span (from JSON imports) sort to the end.
     unresolved.sort_by_key(|(_, span)| {
         span.as_ref()
-            .map_or(("", usize::MAX), |sws| (sws.file_name, sws.offset))
+            .map_or(("", usize::MAX), |s| (s.file_name, s.offset))
     });
 
     if unresolved.is_empty() {
@@ -1080,7 +1072,7 @@ fn validate_all_references(
         // spans). Use the first available import statement span to point
         // the user at the import line, with a help message naming the
         // imported file(s).
-        let first_import_sws = json_import_spans.iter().find_map(|(_, s)| s.clone());
+        let first_import_span = json_import_spans.iter().find_map(|(_, s)| *s);
 
         let names: Vec<&str> = without_span.iter().map(|(name, _)| name.as_str()).collect();
         let message = format!("Undefined name: {}", names.join(", "));
@@ -1094,9 +1086,9 @@ fn validate_all_references(
             ))
         };
 
-        if let Some(sws) = first_import_sws {
+        if let Some(span) = first_import_span {
             return Err(ParseDiagnostic {
-                src: sws,
+                span,
                 message,
                 label: Some("this import contains undefined type references".to_string()),
                 help,
@@ -1117,15 +1109,15 @@ fn validate_all_references(
     // are attached as related diagnostics so users see all undefined names
     // in one error report.
     let mut span_iter = with_span.into_iter();
-    let (first_name, first_sws) = span_iter.next().expect("with_span is non-empty");
-    let first_sws = first_sws.expect("partitioned into Some");
+    let (first_name, first_span) = span_iter.next().expect("with_span is non-empty");
+    let first_span = first_span.expect("partitioned into Some");
 
     let mut related: Vec<ParseDiagnostic> = span_iter
         .map(|(name, span)| {
-            let sws = span.expect("partitioned into Some");
+            let span = span.expect("partitioned into Some");
             let help = suggest_similar_name(&name, registry);
             ParseDiagnostic {
-                src: sws,
+                span,
                 message: format!("Undefined name: {name}"),
                 label: None,
                 help,
@@ -1138,17 +1130,17 @@ fn validate_all_references(
     // statement spans so the user can see which import brought them in.
     // Fall back to a zero-length span at offset 0 if no import span is
     // available. Include "did you mean?" suggestions where applicable.
-    let fallback_sws = SpanWithSource::new(0, 0, source_name, source);
+    let fallback_span = SpanWithSource::new(0, 0, source_name, source);
     for (name, _) in &without_span {
-        let (sws, label) = if let Some((path, Some(import_sws))) = json_import_spans.first() {
+        let (span, label) = if let Some((path, Some(import_span))) = json_import_spans.first() {
             (
-                import_sws.clone(),
+                *import_span,
                 Some(format!(
                     "type `{name}` referenced in imported file `{path}`"
                 )),
             )
         } else {
-            (fallback_sws.clone(), None)
+            (fallback_span, None)
         };
 
         let help = if import_file_names.is_empty() {
@@ -1161,7 +1153,7 @@ fn validate_all_references(
         };
 
         related.push(ParseDiagnostic {
-            src: sws,
+            span,
             message: format!("Undefined name: {name}"),
             label,
             help,
@@ -1171,7 +1163,7 @@ fn validate_all_references(
 
     let first_help = suggest_similar_name(&first_name, registry);
     Err(ParseDiagnostic {
-        src: first_sws,
+        span: first_span,
         message: format!("Undefined name: {first_name}"),
         label: None,
         help: first_help,

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -22,7 +22,6 @@ use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 use miette::Context;
 use serde_json::Value;
@@ -66,9 +65,9 @@ struct CompileOutput {
     warnings: Vec<miette::Report>,
     /// Original source text, retained for error diagnostics in type-specific
     /// serialization logic.
-    source: Arc<str>,
+    source: &'static str,
     /// Name used for the source in diagnostics (e.g., file path or `"<input>"`).
-    source_name: Arc<str>,
+    source_name: &'static str,
 }
 
 impl IdlCompiler {
@@ -105,13 +104,19 @@ impl IdlCompiler {
         let dir = dir.canonicalize().unwrap_or(dir);
         let canonical_path = path.canonicalize().ok();
 
-        self.compile(&source, &source_name, &dir, canonical_path)
+        let source = source.leak();
+        let source_name = source_name.leak();
+        self.compile(source, source_name, &dir, canonical_path)
     }
 
     /// Compile an IDL source string using the current working directory as the
     /// import base. This is the shared implementation behind
     /// `Idl::convert_str_named` and `Idl2Schemata::extract_str_named`.
-    fn compile_str(&mut self, source: &str, name: &str) -> miette::Result<CompileOutput> {
+    fn compile_str(
+        &mut self,
+        source: &'static str,
+        name: &'static str,
+    ) -> miette::Result<CompileOutput> {
         let cwd = std::env::current_dir()
             .map_err(|e| miette::miette!("{e}"))
             .context("determine current directory")?;
@@ -127,8 +132,8 @@ impl IdlCompiler {
     /// are available via [`drain_warnings`](Self::drain_warnings).
     fn compile(
         &mut self,
-        source: &str,
-        source_name: &str,
+        source: &'static str,
+        source_name: &'static str,
         input_dir: &Path,
         input_path: Option<PathBuf>,
     ) -> miette::Result<CompileOutput> {
@@ -164,8 +169,8 @@ impl IdlCompiler {
             idl_file,
             registry,
             warnings,
-            source: Arc::from(source),
-            source_name: Arc::from(source_name),
+            source,
+            source_name,
         })
     }
 }
@@ -282,13 +287,17 @@ impl Idl {
 
     /// Compile an IDL source string to JSON. Uses `"<input>"` as the source
     /// name in diagnostics.
-    pub fn convert_str(&mut self, source: &str) -> miette::Result<IdlOutput> {
+    pub fn convert_str(&mut self, source: &'static str) -> miette::Result<IdlOutput> {
         self.convert_str_named(source, "<input>")
     }
 
     /// Compile an IDL source string to JSON with a custom source name for
     /// diagnostics.
-    pub fn convert_str_named(&mut self, source: &str, name: &str) -> miette::Result<IdlOutput> {
+    pub fn convert_str_named(
+        &mut self,
+        source: &'static str,
+        name: &'static str,
+    ) -> miette::Result<IdlOutput> {
         let compiled = self.inner.compile_str(source, name)?;
         self.convert_impl(compiled)
     }
@@ -321,7 +330,7 @@ impl Idl {
 
             let span_len = source.len().min(1);
             return Err(ParseDiagnostic {
-                src: SpanWithSource::new(0, span_len, Arc::clone(&source_name), Arc::clone(&source)),
+                src: SpanWithSource::new(0, span_len, source_name, source),
                 message: "IDL file contains neither a protocol nor a schema declaration"
                     .to_string(),
                 label: Some("this file".to_string()),
@@ -465,7 +474,7 @@ impl Idl2Schemata {
     }
 
     /// Extract named schemas from an IDL source string.
-    pub fn extract_str(&mut self, source: &str) -> miette::Result<SchemataOutput> {
+    pub fn extract_str(&mut self, source: &'static str) -> miette::Result<SchemataOutput> {
         self.extract_str_named(source, "<input>")
     }
 
@@ -473,8 +482,8 @@ impl Idl2Schemata {
     /// name for diagnostics.
     pub fn extract_str_named(
         &mut self,
-        source: &str,
-        name: &str,
+        source: &'static str,
+        name: &'static str,
     ) -> miette::Result<SchemataOutput> {
         let compiled = self.inner.compile_str(source, name)?;
         Ok(Self::extract_impl(compiled))
@@ -592,14 +601,14 @@ impl CompileContext {
 /// declaration items (imports and local types) in source order, and we
 /// process them sequentially, so the registry reflects declaration order.
 fn parse_and_resolve(
-    source: &str,
-    source_name: &str,
+    source: &'static str,
+    source_name: &'static str,
     input_dir: &Path,
     input_path: Option<PathBuf>,
     ctx: &mut CompileContext,
 ) -> miette::Result<(IdlFile, SchemaRegistry)> {
     let (idl_file, decl_items, local_warnings) =
-        parse_idl_named(Arc::from(source), Arc::from(source_name)).context("parse IDL source")?;
+        parse_idl_named(source, source_name).context("parse IDL source")?;
 
     // Immediately convert local warnings into `miette::Report`s and store
     // them in `ctx.warnings`. This must happen before any fallible operation
@@ -700,7 +709,10 @@ fn process_decl_items(
                         let msg = format!(
                             "Invalid default for field `{field_name}` in `{type_name}`: {reason}"
                         );
-                        let effective_sws = field_spans.get(&field_name).cloned().or_else(|| span.clone());
+                        let effective_sws = field_spans
+                            .get(&field_name)
+                            .cloned()
+                            .or_else(|| span.clone());
                         effective_sws.map(|sws| ParseDiagnostic {
                             src: sws,
                             message: msg,
@@ -717,7 +729,10 @@ fn process_decl_items(
                 // Prefer the per-field span (from the variable declaration)
                 // over the type-level span (from the record keyword), so the
                 // diagnostic highlights the offending field, not the record.
-                let effective_sws = field_spans.get(&first_field).cloned().or_else(|| span.clone());
+                let effective_sws = field_spans
+                    .get(&first_field)
+                    .cloned()
+                    .or_else(|| span.clone());
                 if let Some(sws) = effective_sws {
                     return Err(ParseDiagnostic {
                         src: sws,
@@ -784,9 +799,8 @@ fn resolve_single_import(
                 .push((resolved_path.display().to_string(), import.span.clone()));
         }
         ImportKind::Schema => {
-            import_schema(&resolved_path, &mut ctx.registry).map_err(|e| {
-                wrap_import_error(e, import.span.clone(), &resolved_path, "schema")
-            })?;
+            import_schema(&resolved_path, &mut ctx.registry)
+                .map_err(|e| wrap_import_error(e, import.span.clone(), &resolved_path, "schema"))?;
 
             // Track the import so unresolved references from this .avsc can
             // be attributed to the import statement in error diagnostics.
@@ -794,14 +808,14 @@ fn resolve_single_import(
                 .push((resolved_path.display().to_string(), import.span.clone()));
         }
         ImportKind::Idl => {
-            let imported_source: Arc<str> = fs::read_to_string(&resolved_path)
+            let imported_source = fs::read_to_string(&resolved_path)
                 .map_err(|e| miette::miette!("{e}"))
                 .with_context(|| format!("read imported IDL {}", resolved_path.display()))
-                .map(|s| Arc::from(s.as_str()))?;
+                .map(String::leak)?;
 
-            let imported_name: Arc<str> = Arc::from(resolved_path.display().to_string());
+            let imported_name = resolved_path.display().to_string().leak();
             let (imported_idl, nested_decl_items, import_warnings) =
-                parse_idl_named(Arc::clone(&imported_source), Arc::clone(&imported_name))
+                parse_idl_named(imported_source, imported_name)
                     .with_context(|| format!("parse imported IDL {}", resolved_path.display()))?;
 
             // Propagate warnings from the imported file, wrapping each with the
@@ -824,10 +838,9 @@ fn resolve_single_import(
             // IDL imports use their own source text for span tracking, so
             // `ctx.json_import_spans` is passed through to capture any nested
             // JSON imports within the imported IDL file.
-            process_decl_items(&nested_decl_items, ctx, &import_dir)
-                .with_context(|| {
-                    format!("resolve nested imports from `{}`", resolved_path.display())
-                })?;
+            process_decl_items(&nested_decl_items, ctx, &import_dir).with_context(|| {
+                format!("resolve nested imports from `{}`", resolved_path.display())
+            })?;
         }
     }
 
@@ -993,8 +1006,8 @@ fn suggest_similar_name(unresolved: &str, registry: &SchemaRegistry) -> Option<S
 fn validate_all_references(
     idl_file: &IdlFile,
     registry: &SchemaRegistry,
-    source: &str,
-    source_name: &str,
+    source: &'static str,
+    source_name: &'static str,
     json_import_spans: &[(String, Option<SpanWithSource>)],
 ) -> miette::Result<()> {
     let mut unresolved = registry.validate_references();
@@ -1042,9 +1055,8 @@ fn validate_all_references(
     // Sort by source span offset so the first error in the file is reported
     // first. References without a span (from JSON imports) sort to the end.
     unresolved.sort_by_key(|(_, span)| {
-        span.as_ref().map_or(("".to_string(), usize::MAX), |sws| {
-            ((*sws.file_name).to_string(), sws.offset)
-        })
+        span.as_ref()
+            .map_or(("", usize::MAX), |sws| (sws.file_name, sws.offset))
     });
 
     if unresolved.is_empty() {
@@ -1108,11 +1120,6 @@ fn validate_all_references(
     let (first_name, first_sws) = span_iter.next().expect("with_span is non-empty");
     let first_sws = first_sws.expect("partitioned into Some");
 
-    // Fallback SWS for spanless references: points at the root file with a
-    // zero-length span when no import statement span is available.
-    let fallback_sws =
-        SpanWithSource::new(0, 0, Arc::from(source_name), Arc::from(source));
-
     let mut related: Vec<ParseDiagnostic> = span_iter
         .map(|(name, span)| {
             let sws = span.expect("partitioned into Some");
@@ -1129,8 +1136,9 @@ fn validate_all_references(
 
     // Append spanless references as related diagnostics, using the import
     // statement spans so the user can see which import brought them in.
-    // Fall back to `fallback_sws` if no import span is
+    // Fall back to a zero-length span at offset 0 if no import span is
     // available. Include "did you mean?" suggestions where applicable.
+    let fallback_sws = SpanWithSource::new(0, 0, source_name, source);
     for (name, _) in &without_span {
         let (sws, label) = if let Some((path, Some(import_sws))) = json_import_spans.first() {
             (

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -22,11 +22,12 @@ use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use miette::Context;
 use serde_json::Value;
 
-use crate::error::ParseDiagnostic;
+use crate::error::{ParseDiagnostic, SpanWithSource};
 use crate::import::{ImportContext, import_protocol, import_schema};
 use crate::model::json::{build_lookup, protocol_to_json, schema_to_json};
 use crate::model::protocol::Message;
@@ -65,9 +66,9 @@ struct CompileOutput {
     warnings: Vec<miette::Report>,
     /// Original source text, retained for error diagnostics in type-specific
     /// serialization logic.
-    source: String,
+    source: Arc<str>,
     /// Name used for the source in diagnostics (e.g., file path or `"<input>"`).
-    source_name: String,
+    source_name: Arc<str>,
 }
 
 impl IdlCompiler {
@@ -163,8 +164,8 @@ impl IdlCompiler {
             idl_file,
             registry,
             warnings,
-            source: source.to_string(),
-            source_name: source_name.to_string(),
+            source: Arc::from(source),
+            source_name: Arc::from(source_name),
         })
     }
 }
@@ -320,8 +321,7 @@ impl Idl {
 
             let span_len = source.len().min(1);
             return Err(ParseDiagnostic {
-                src: miette::NamedSource::new(source_name, source),
-                span: (0, span_len).into(),
+                src: SpanWithSource::new(0, span_len, Arc::clone(&source_name), Arc::clone(&source)),
                 message: "IDL file contains neither a protocol nor a schema declaration"
                     .to_string(),
                 label: Some("this file".to_string()),
@@ -565,7 +565,7 @@ struct CompileContext {
     /// in the IDL source. Used to enrich error messages for unresolved
     /// references from `.avsc`/`.avpr` imports, which lack source spans of
     /// their own.
-    json_import_spans: Vec<(String, Option<miette::SourceSpan>)>,
+    json_import_spans: Vec<(String, Option<SpanWithSource>)>,
 }
 
 impl CompileContext {
@@ -599,7 +599,7 @@ fn parse_and_resolve(
     ctx: &mut CompileContext,
 ) -> miette::Result<(IdlFile, SchemaRegistry)> {
     let (idl_file, decl_items, local_warnings) =
-        parse_idl_named(source, source_name).context("parse IDL source")?;
+        parse_idl_named(Arc::from(source), Arc::from(source_name)).context("parse IDL source")?;
 
     // Immediately convert local warnings into `miette::Report`s and store
     // them in `ctx.warnings`. This must happen before any fallible operation
@@ -631,7 +631,7 @@ fn parse_and_resolve(
     // Process declaration items in source order: resolve imports when
     // encountered, register local types when encountered. Any import-derived
     // warnings are appended to `ctx.warnings` by `process_decl_items`.
-    process_decl_items(&decl_items, ctx, input_dir, source, source_name)?;
+    process_decl_items(&decl_items, ctx, input_dir)?;
 
     // For protocol files, rebuild the types list from the registry (which now
     // includes imported types in declaration order) and prepend imported
@@ -659,20 +659,17 @@ fn process_decl_items(
     decl_items: &[DeclItem],
     ctx: &mut CompileContext,
     current_dir: &Path,
-    source: &str,
-    source_name: &str,
 ) -> miette::Result<()> {
     for item in decl_items {
         match item {
             DeclItem::Import(import) => {
-                resolve_single_import(import, ctx, current_dir, source, source_name)?;
+                resolve_single_import(import, ctx, current_dir)?;
             }
             DeclItem::Type(schema, span, field_spans) => {
                 if let Err(msg) = ctx.registry.register(schema.as_ref().clone()) {
-                    if let Some(span) = span {
+                    if let Some(sws) = span.as_ref() {
                         return Err(ParseDiagnostic {
-                            src: miette::NamedSource::new(source_name, source.to_string()),
-                            span: *span,
+                            src: sws.clone(),
                             message: msg,
                             label: None,
                             help: None,
@@ -703,10 +700,9 @@ fn process_decl_items(
                         let msg = format!(
                             "Invalid default for field `{field_name}` in `{type_name}`: {reason}"
                         );
-                        let effective_span = field_spans.get(&field_name).copied().or(*span);
-                        effective_span.map(|span| ParseDiagnostic {
-                            src: miette::NamedSource::new(source_name, source.to_string()),
-                            span,
+                        let effective_sws = field_spans.get(&field_name).cloned().or_else(|| span.clone());
+                        effective_sws.map(|sws| ParseDiagnostic {
+                            src: sws,
                             message: msg,
                             label: None,
                             help: None,
@@ -721,11 +717,10 @@ fn process_decl_items(
                 // Prefer the per-field span (from the variable declaration)
                 // over the type-level span (from the record keyword), so the
                 // diagnostic highlights the offending field, not the record.
-                let effective_span = field_spans.get(&first_field).copied().or(*span);
-                if let Some(span) = effective_span {
+                let effective_sws = field_spans.get(&first_field).cloned().or_else(|| span.clone());
+                if let Some(sws) = effective_sws {
                     return Err(ParseDiagnostic {
-                        src: miette::NamedSource::new(source_name, source.to_string()),
-                        span,
+                        src: sws,
                         message: first_msg,
                         label: None,
                         help: None,
@@ -747,16 +742,13 @@ fn resolve_single_import(
     import: &crate::reader::ImportEntry,
     ctx: &mut CompileContext,
     current_dir: &Path,
-    source: &str,
-    source_name: &str,
 ) -> miette::Result<()> {
     let resolved_path = match ctx.import_ctx.resolve_import(&import.path, current_dir) {
         Ok(p) => p,
         Err(e) => {
-            if let Some(span) = import.span {
+            if let Some(sws) = import.span.clone() {
                 return Err(ParseDiagnostic {
-                    src: miette::NamedSource::new(source_name, source.to_string()),
-                    span,
+                    src: sws,
                     message: format!("{e}"),
                     label: None,
                     help: None,
@@ -782,47 +774,34 @@ fn resolve_single_import(
         ImportKind::Protocol => {
             let imported_messages =
                 import_protocol(&resolved_path, &mut ctx.registry).map_err(|e| {
-                    wrap_import_error(
-                        e,
-                        import.span,
-                        source,
-                        source_name,
-                        &resolved_path,
-                        "protocol",
-                    )
+                    wrap_import_error(e, import.span.clone(), &resolved_path, "protocol")
                 })?;
             ctx.messages.extend(imported_messages);
 
             // Track the import so unresolved references from this .avpr can
             // be attributed to the import statement in error diagnostics.
             ctx.json_import_spans
-                .push((resolved_path.display().to_string(), import.span));
+                .push((resolved_path.display().to_string(), import.span.clone()));
         }
         ImportKind::Schema => {
             import_schema(&resolved_path, &mut ctx.registry).map_err(|e| {
-                wrap_import_error(
-                    e,
-                    import.span,
-                    source,
-                    source_name,
-                    &resolved_path,
-                    "schema",
-                )
+                wrap_import_error(e, import.span.clone(), &resolved_path, "schema")
             })?;
 
             // Track the import so unresolved references from this .avsc can
             // be attributed to the import statement in error diagnostics.
             ctx.json_import_spans
-                .push((resolved_path.display().to_string(), import.span));
+                .push((resolved_path.display().to_string(), import.span.clone()));
         }
         ImportKind::Idl => {
-            let imported_source = fs::read_to_string(&resolved_path)
+            let imported_source: Arc<str> = fs::read_to_string(&resolved_path)
                 .map_err(|e| miette::miette!("{e}"))
-                .with_context(|| format!("read imported IDL {}", resolved_path.display()))?;
+                .with_context(|| format!("read imported IDL {}", resolved_path.display()))
+                .map(|s| Arc::from(s.as_str()))?;
 
-            let imported_name = resolved_path.display().to_string();
+            let imported_name: Arc<str> = Arc::from(resolved_path.display().to_string());
             let (imported_idl, nested_decl_items, import_warnings) =
-                parse_idl_named(&imported_source, &imported_name)
+                parse_idl_named(Arc::clone(&imported_source), Arc::clone(&imported_name))
                     .with_context(|| format!("parse imported IDL {}", resolved_path.display()))?;
 
             // Propagate warnings from the imported file, wrapping each with the
@@ -845,16 +824,10 @@ fn resolve_single_import(
             // IDL imports use their own source text for span tracking, so
             // `ctx.json_import_spans` is passed through to capture any nested
             // JSON imports within the imported IDL file.
-            process_decl_items(
-                &nested_decl_items,
-                ctx,
-                &import_dir,
-                &imported_source,
-                &imported_name,
-            )
-            .with_context(|| {
-                format!("resolve nested imports from `{}`", resolved_path.display())
-            })?;
+            process_decl_items(&nested_decl_items, ctx, &import_dir)
+                .with_context(|| {
+                    format!("resolve nested imports from `{}`", resolved_path.display())
+                })?;
         }
     }
 
@@ -871,16 +844,13 @@ fn resolve_single_import(
 /// diagnostic -- context layers are shown as plain text.
 fn wrap_import_error(
     error: miette::Report,
-    span: Option<miette::SourceSpan>,
-    source: &str,
-    source_name: &str,
+    span: Option<SpanWithSource>,
     resolved_path: &Path,
     kind: &str,
 ) -> miette::Report {
-    if let Some(span) = span {
+    if let Some(sws) = span {
         let diag = ParseDiagnostic {
-            src: miette::NamedSource::new(source_name, source.to_string()),
-            span,
+            src: sws,
             message: format!("import {} {}", kind, resolved_path.display()),
             label: None,
             help: None,
@@ -1025,7 +995,7 @@ fn validate_all_references(
     registry: &SchemaRegistry,
     source: &str,
     source_name: &str,
-    json_import_spans: &[(String, Option<miette::SourceSpan>)],
+    json_import_spans: &[(String, Option<SpanWithSource>)],
 ) -> miette::Result<()> {
     let mut unresolved = registry.validate_references();
 
@@ -1071,7 +1041,11 @@ fn validate_all_references(
 
     // Sort by source span offset so the first error in the file is reported
     // first. References without a span (from JSON imports) sort to the end.
-    unresolved.sort_by_key(|(_, span)| span.map_or(usize::MAX, |s| s.offset()));
+    unresolved.sort_by_key(|(_, span)| {
+        span.as_ref().map_or(("".to_string(), usize::MAX), |sws| {
+            ((*sws.file_name).to_string(), sws.offset)
+        })
+    });
 
     if unresolved.is_empty() {
         return Ok(());
@@ -1094,7 +1068,7 @@ fn validate_all_references(
         // spans). Use the first available import statement span to point
         // the user at the import line, with a help message naming the
         // imported file(s).
-        let first_import_span = json_import_spans.iter().find_map(|(_, s)| *s);
+        let first_import_sws = json_import_spans.iter().find_map(|(_, s)| s.clone());
 
         let names: Vec<&str> = without_span.iter().map(|(name, _)| name.as_str()).collect();
         let message = format!("Undefined name: {}", names.join(", "));
@@ -1108,10 +1082,9 @@ fn validate_all_references(
             ))
         };
 
-        if let Some(span) = first_import_span {
+        if let Some(sws) = first_import_sws {
             return Err(ParseDiagnostic {
-                src: miette::NamedSource::new(source_name, source.to_string()),
-                span,
+                src: sws,
                 message,
                 label: Some("this import contains undefined type references".to_string()),
                 help,
@@ -1132,16 +1105,20 @@ fn validate_all_references(
     // are attached as related diagnostics so users see all undefined names
     // in one error report.
     let mut span_iter = with_span.into_iter();
-    let (first_name, first_span) = span_iter.next().expect("with_span is non-empty");
-    let first_span = first_span.expect("partitioned into Some");
+    let (first_name, first_sws) = span_iter.next().expect("with_span is non-empty");
+    let first_sws = first_sws.expect("partitioned into Some");
+
+    // Fallback SWS for spanless references: points at the root file with a
+    // zero-length span when no import statement span is available.
+    let fallback_sws =
+        SpanWithSource::new(0, 0, Arc::from(source_name), Arc::from(source));
 
     let mut related: Vec<ParseDiagnostic> = span_iter
         .map(|(name, span)| {
-            let span = span.expect("partitioned into Some");
+            let sws = span.expect("partitioned into Some");
             let help = suggest_similar_name(&name, registry);
             ParseDiagnostic {
-                src: miette::NamedSource::new(source_name, source.to_string()),
-                span,
+                src: sws,
                 message: format!("Undefined name: {name}"),
                 label: None,
                 help,
@@ -1152,19 +1129,18 @@ fn validate_all_references(
 
     // Append spanless references as related diagnostics, using the import
     // statement spans so the user can see which import brought them in.
-    // Fall back to a zero-length span at offset 0 if no import span is
+    // Fall back to `fallback_sws` if no import span is
     // available. Include "did you mean?" suggestions where applicable.
-    let fallback_span: miette::SourceSpan = (0, 0).into();
     for (name, _) in &without_span {
-        let (span, label) = if let Some((path, Some(import_span))) = json_import_spans.first() {
+        let (sws, label) = if let Some((path, Some(import_sws))) = json_import_spans.first() {
             (
-                *import_span,
+                import_sws.clone(),
                 Some(format!(
                     "type `{name}` referenced in imported file `{path}`"
                 )),
             )
         } else {
-            (fallback_span, None)
+            (fallback_sws.clone(), None)
         };
 
         let help = if import_file_names.is_empty() {
@@ -1177,8 +1153,7 @@ fn validate_all_references(
         };
 
         related.push(ParseDiagnostic {
-            src: miette::NamedSource::new(source_name, source.to_string()),
-            span,
+            src: sws,
             message: format!("Undefined name: {name}"),
             label,
             help,
@@ -1188,8 +1163,7 @@ fn validate_all_references(
 
     let first_help = suggest_similar_name(&first_name, registry);
     Err(ParseDiagnostic {
-        src: miette::NamedSource::new(source_name, source.to_string()),
-        span: first_span,
+        src: first_sws,
         message: format!("Undefined name: {first_name}"),
         label: None,
         help: first_help,

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1048,7 +1048,7 @@ fn validate_all_references(
     // first. References without a span (from JSON imports) sort to the end.
     unresolved.sort_by_key(|(_, span)| {
         span.as_ref()
-            .map_or(("", usize::MAX), |s| (s.file_name, s.offset))
+            .map_or(("", usize::MAX), |s| (s.name, s.offset))
     });
 
     if unresolved.is_empty() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@ use miette::{Diagnostic, LabeledSpan, MietteError, MietteSpanContents, SourceCod
 /// every diagnostic — including those from imported files — can render the
 /// correct source excerpt and filename.
 ///
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct SpanWithSource {
     pub offset: usize,
     pub length: usize,
@@ -72,7 +72,7 @@ impl SourceCode for SpanWithSource {
 /// source-underline label.
 #[derive(Debug)]
 pub struct ParseDiagnostic {
-    pub src: SpanWithSource,
+    pub span: SpanWithSource,
     pub message: String,
     /// Shorter label for the source-underline annotation. When `None`, falls
     /// back to `message`.
@@ -113,7 +113,7 @@ pub(crate) fn render_diagnostic(report: &miette::Report) -> String {
 
 impl miette::Diagnostic for ParseDiagnostic {
     fn source_code(&self) -> Option<&dyn SourceCode> {
-        Some(&self.src)
+        Some(&self.span)
     }
 
     fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
@@ -126,7 +126,7 @@ impl miette::Diagnostic for ParseDiagnostic {
         let label_text = self.label.clone().unwrap_or_else(|| self.message.clone());
         Some(Box::new(std::iter::once(LabeledSpan::new_with_span(
             Some(label_text),
-            self.src.source_span(),
+            self.span.source_span(),
         ))))
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use miette::{Diagnostic, LabeledSpan, MietteError, MietteSpanContents, SourceCode, SourceSpan};
 
 /// A source span paired with the file it points into.
@@ -13,13 +11,18 @@ pub struct SpanWithSource {
     pub offset: usize,
     pub length: usize,
     /// Absolute path of the file that contains this span.
-    pub file_name: Arc<str>,
+    pub file_name: &'static str,
     /// Full source text of that file.
-    pub content: Arc<str>,
+    pub content: &'static str,
 }
 
 impl SpanWithSource {
-    pub fn new(offset: usize, length: usize, file_name: Arc<str>, content: Arc<str>) -> Self {
+    pub fn new(
+        offset: usize,
+        length: usize,
+        file_name: &'static str,
+        content: &'static str,
+    ) -> Self {
         SpanWithSource {
             offset,
             length,
@@ -40,7 +43,12 @@ impl SourceCode for SpanWithSource {
         context_lines_before: usize,
         context_lines_after: usize,
     ) -> Result<Box<dyn miette::SpanContents<'a> + 'a>, MietteError> {
-        let inner = SourceCode::read_span(&self.content, span, context_lines_before, context_lines_after)?;
+        let inner = SourceCode::read_span(
+            &self.content,
+            span,
+            context_lines_before,
+            context_lines_after,
+        )?;
         Ok(Box::new(MietteSpanContents::new_named(
             self.file_name.to_string(),
             inner.data(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,7 +11,7 @@ pub struct SpanWithSource {
     pub offset: usize,
     pub length: usize,
     /// Absolute path of the file that contains this span.
-    pub file_name: &'static str,
+    pub name: &'static str,
     /// Full source text of that file.
     pub content: &'static str,
 }
@@ -26,7 +26,7 @@ impl SpanWithSource {
         SpanWithSource {
             offset,
             length,
-            file_name,
+            name: file_name,
             content,
         }
     }
@@ -50,7 +50,7 @@ impl SourceCode for SpanWithSource {
             context_lines_after,
         )?;
         Ok(Box::new(MietteSpanContents::new_named(
-            self.file_name.to_string(),
+            self.name.to_string(),
             inner.data(),
             *inner.span(),
             inner.line(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,56 @@
-use miette::{Diagnostic, LabeledSpan, NamedSource, SourceSpan};
+use std::sync::Arc;
+
+use miette::{Diagnostic, LabeledSpan, MietteError, MietteSpanContents, SourceCode, SourceSpan};
+
+/// A source span paired with the file it points into.
+///
+/// Stored in `ParseDiagnostic`, `Warning`, and `AvroSchema::Reference` so that
+/// every diagnostic — including those from imported files — can render the
+/// correct source excerpt and filename.
+///
+#[derive(Debug, Clone, PartialEq)]
+pub struct SpanWithSource {
+    pub offset: usize,
+    pub length: usize,
+    /// Absolute path of the file that contains this span.
+    pub file_name: Arc<str>,
+    /// Full source text of that file.
+    pub content: Arc<str>,
+}
+
+impl SpanWithSource {
+    pub fn new(offset: usize, length: usize, file_name: Arc<str>, content: Arc<str>) -> Self {
+        SpanWithSource {
+            offset,
+            length,
+            file_name,
+            content,
+        }
+    }
+
+    pub(crate) fn source_span(&self) -> SourceSpan {
+        SourceSpan::new(self.offset.into(), self.length)
+    }
+}
+
+impl SourceCode for SpanWithSource {
+    fn read_span<'a>(
+        &'a self,
+        span: &SourceSpan,
+        context_lines_before: usize,
+        context_lines_after: usize,
+    ) -> Result<Box<dyn miette::SpanContents<'a> + 'a>, MietteError> {
+        let inner = SourceCode::read_span(&self.content, span, context_lines_before, context_lines_after)?;
+        Ok(Box::new(MietteSpanContents::new_named(
+            self.file_name.to_string(),
+            inner.data(),
+            *inner.span(),
+            inner.line(),
+            inner.column(),
+            inner.line_count(),
+        )))
+    }
+}
 
 /// A parse error with source location information for rich diagnostics.
 ///
@@ -12,8 +64,7 @@ use miette::{Diagnostic, LabeledSpan, NamedSource, SourceSpan};
 /// source-underline label.
 #[derive(Debug)]
 pub struct ParseDiagnostic {
-    pub src: NamedSource<String>,
-    pub span: SourceSpan,
+    pub src: SpanWithSource,
     pub message: String,
     /// Shorter label for the source-underline annotation. When `None`, falls
     /// back to `message`.
@@ -53,7 +104,7 @@ pub(crate) fn render_diagnostic(report: &miette::Report) -> String {
 }
 
 impl miette::Diagnostic for ParseDiagnostic {
-    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+    fn source_code(&self) -> Option<&dyn SourceCode> {
         Some(&self.src)
     }
 
@@ -67,7 +118,7 @@ impl miette::Diagnostic for ParseDiagnostic {
         let label_text = self.label.clone().unwrap_or_else(|| self.message.clone());
         Some(Box::new(std::iter::once(LabeledSpan::new_with_span(
             Some(label_text),
-            self.span,
+            self.src.source_span(),
         ))))
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,8 +206,9 @@ fn run_idl(
             io::stdin()
                 .read_to_string(&mut source)
                 .map_err(|e| miette::miette!("{e}: read IDL from stdin"))?;
-            let source_name = input.as_deref().unwrap_or("<stdin>");
-            builder.convert_str_named(&source, source_name)
+            let source_name = input.map(|s| &*String::leak(s)).unwrap_or("<stdin>");
+            let source = source.leak();
+            builder.convert_str_named(source, source_name)
         }
     };
 

--- a/src/model/schema.rs
+++ b/src/model/schema.rs
@@ -1,9 +1,10 @@
-use miette::SourceSpan;
 use serde_json::Value;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
+
+use crate::error::SpanWithSource;
 
 /// The eight Avro primitive type names.
 ///
@@ -370,10 +371,10 @@ pub enum AvroSchema {
         name: std::string::String,
         namespace: Option<std::string::String>,
         properties: HashMap<std::string::String, Value>,
-        /// Source location of this reference in the `.avdl` input, used for
-        /// error diagnostics when the reference cannot be resolved. `None` for
-        /// references created from JSON imports (no source location available).
-        span: Option<SourceSpan>,
+        /// Source location and file of this reference in the `.avdl` input,
+        /// used for error diagnostics when the reference cannot be resolved.
+        /// `None` for references created from JSON imports.
+        span: Option<SpanWithSource>,
     },
 }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -63,7 +63,7 @@ use miette::{Context, Result};
 pub(crate) struct Warning {
     pub(crate) message: String,
     /// Source (file, source-code, offsets) of the problematic token
-    pub(crate) src: Option<SpanWithSource>,
+    pub(crate) span: Option<SpanWithSource>,
 }
 
 /// Custom `Debug` implementation that shows a compact representation instead of
@@ -75,11 +75,11 @@ impl std::fmt::Debug for Warning {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Warning")
             .field("message", &self.message)
-            .field("file", &self.src.as_ref().map(|s| s.file_name))
+            .field("file", &self.span.as_ref().map(|s| s.file_name))
             .field(
                 "span",
                 &self
-                    .src
+                    .span
                     .as_ref()
                     .map(|s| format!("{}..{}", s.offset, s.offset + s.length)),
             )
@@ -123,7 +123,7 @@ impl Warning {
                 // get_column() is 0-based, so we add 1 to match.
                 column + 1,
             ),
-            src: Some(src.span(offset, length)),
+            span: Some(src.span(offset, length)),
         }
     }
 
@@ -162,7 +162,7 @@ impl Warning {
             message: format!(
                 "Annotations on union types are not supported and will be ignored: {keys_display}"
             ),
-            src: Some(src.span(byte_offset, length)),
+            span: Some(src.span(byte_offset, length)),
         }
     }
 }
@@ -183,11 +183,11 @@ impl miette::Diagnostic for Warning {
     }
 
     fn source_code(&self) -> Option<&dyn miette::SourceCode> {
-        self.src.as_ref().map(|s| s as &dyn miette::SourceCode)
+        self.span.as_ref().map(|s| s as &dyn miette::SourceCode)
     }
 
     fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
-        let sws = self.src.as_ref()?;
+        let span = self.span.as_ref()?;
         // Derive a short label from the message content rather than hardcoding
         // a single label for all warning types.
         let label = if self.message.contains("out-of-place documentation comment") {
@@ -200,7 +200,7 @@ impl miette::Diagnostic for Warning {
             "here"
         };
         Some(Box::new(std::iter::once(
-            miette::LabeledSpan::new_with_span(Some(label.to_string()), sws.source_span()),
+            miette::LabeledSpan::new_with_span(Some(label.to_string()), span.source_span()),
         )))
     }
 }
@@ -2030,7 +2030,7 @@ pub fn parse_idl_named(
         .iter()
         .map(|e| Warning {
             message: e.message.clone(),
-            src: Some(SpanWithSource::new(e.offset, e.length, source_name, input)),
+            span: Some(SpanWithSource::new(e.offset, e.length, source_name, input)),
         })
         .collect();
 
@@ -2068,7 +2068,7 @@ pub fn parse_idl_named(
             };
 
             return Err(ParseDiagnostic {
-                src: SpanWithSource::new(unterm.offset, unterm.length, source_name, input),
+                span: SpanWithSource::new(unterm.offset, unterm.length, source_name, input),
                 message,
                 label: Some("unterminated string literal".to_string()),
                 help: Some(
@@ -2091,7 +2091,7 @@ pub fn parse_idl_named(
         let related: Vec<ParseDiagnostic> = errors_to_report[1..]
             .iter()
             .map(|e| ParseDiagnostic {
-                src: SpanWithSource::new(e.offset, e.length, source_name, input),
+                span: SpanWithSource::new(e.offset, e.length, source_name, input),
                 message: e.message.clone(),
                 label: e.label.clone(),
                 help: e.help.clone(),
@@ -2099,7 +2099,7 @@ pub fn parse_idl_named(
             })
             .collect();
         return Err(ParseDiagnostic {
-            src: SpanWithSource::new(first.offset, first.length, source_name, input),
+            span: SpanWithSource::new(first.offset, first.length, source_name, input),
             message: first.message.clone(),
             label: first.label.clone(),
             help: first.help.clone(),
@@ -2238,7 +2238,7 @@ fn make_diagnostic<'input>(
 
     let message = message.into();
     ParseDiagnostic {
-        src: src.span(offset, length),
+        span: src.span(offset, length),
         message,
         label: None,
         help: None,
@@ -2259,7 +2259,7 @@ fn make_diagnostic_from_token(
 
     let message = message.into();
     ParseDiagnostic {
-        src: src.span(offset, length),
+        span: src.span(offset, length),
         message,
         label: None,
         help: None,
@@ -2268,7 +2268,7 @@ fn make_diagnostic_from_token(
     .into()
 }
 
-/// Extract a `SourceSpan` from a parse tree context's start token.
+/// Extract the span (offset and length) from a parse tree context's start token.
 ///
 /// Returns `None` if the token has no valid position (e.g., synthetic tokens).
 /// Used to attach spans to `DeclItem::Type` and `DeclItem::Import` entries so

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -23,7 +23,6 @@
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::rc::Rc;
-use std::sync::Arc;
 
 use std::borrow::Borrow;
 
@@ -76,7 +75,7 @@ impl std::fmt::Debug for Warning {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Warning")
             .field("message", &self.message)
-            .field("file", &self.src.as_ref().map(|s| &*s.file_name))
+            .field("file", &self.src.as_ref().map(|s| s.file_name))
             .field(
                 "span",
                 &self
@@ -1798,7 +1797,7 @@ struct CollectingErrorListener {
     /// Original source text for line/column-to-byte-offset conversion.
     /// `None` for parser errors where the offending token always provides
     /// byte offsets directly.
-    source: Option<Arc<str>>,
+    source: Option<&'static str>,
 }
 
 impl<'a, T: Recognizer<'a>> ErrorListener<'a, T> for CollectingErrorListener {
@@ -1830,7 +1829,7 @@ impl<'a, T: Recognizer<'a>> ErrorListener<'a, T> for CollectingErrorListener {
             .unwrap_or_else(|| {
                 // Lexer errors have no offending token. Fall back to computing
                 // the byte offset from (line, column) using the source text.
-                if let Some(ref src) = self.source {
+                if let Some(src) = self.source {
                     let offset = line_col_to_byte_offset(src, line, column);
                     (offset, 1)
                 } else {
@@ -1953,23 +1952,23 @@ pub enum DeclItem {
 /// Tests that need to verify CRLF-specific behavior should call
 /// [`parse_idl_named`] directly.
 #[cfg(test)]
-pub fn parse_idl_for_test(input: &str) -> Result<(IdlFile, Vec<DeclItem>, Vec<Warning>)> {
+pub fn parse_idl_for_test(input: &'static str) -> Result<(IdlFile, Vec<DeclItem>, Vec<Warning>)> {
     let normalized;
     let input = if input.contains("\r\n") {
         normalized = input.replace("\r\n", "\n");
-        normalized.as_str()
+        normalized.leak()
     } else {
         input
     };
 
-    parse_idl_named(Arc::from(input), Arc::from("<input>"))
+    parse_idl_named(input, "<input>")
 }
 
 /// Parse an Avro IDL string, attaching `source_name` to any error diagnostics
 /// so that error messages identify the originating file.
 pub fn parse_idl_named(
-    input: Arc<str>,
-    source_name: Arc<str>,
+    input: &'static str,
+    source_name: &'static str,
 ) -> Result<(IdlFile, Vec<DeclItem>, Vec<Warning>)> {
     // The ANTLR grammar's `idlFile` rule includes `('\u001a' .*?)? EOF`
     // to treat the ASCII SUB character (U+001A) as an end-of-file marker,
@@ -1977,12 +1976,11 @@ pub fn parse_idl_named(
     // this correctly, so we strip the SUB character and everything after it
     // before passing the input to the lexer.
     let input = if let Some(pos) = input.find('\u{001a}') {
-        let stripped = &(*input)[..pos];
-        Arc::from(stripped)
+        &input[..pos]
     } else {
         input
     };
-    let input_stream = InputStream::new(&*input);
+    let input_stream = InputStream::new(input);
     let mut lexer = IdlLexer::new(input_stream);
 
     // Replace the lexer's default ConsoleErrorListener with a
@@ -1995,7 +1993,7 @@ pub fn parse_idl_named(
     lexer.remove_error_listeners();
     lexer.add_error_listener(Box::new(CollectingErrorListener {
         errors: Rc::clone(&lexer_errors),
-        source: Some(Arc::clone(&input)),
+        source: Some(input),
     }));
 
     let token_stream = CommonTokenStream::new(lexer);
@@ -2032,12 +2030,7 @@ pub fn parse_idl_named(
         .iter()
         .map(|e| Warning {
             message: e.message.clone(),
-            src: Some(SpanWithSource::new(
-                e.offset,
-                e.length,
-                Arc::clone(&source_name),
-                Arc::clone(&input),
-            )),
+            src: Some(SpanWithSource::new(e.offset, e.length, source_name, input)),
         })
         .collect();
 
@@ -2075,12 +2068,7 @@ pub fn parse_idl_named(
             };
 
             return Err(ParseDiagnostic {
-                src: SpanWithSource::new(
-                    unterm.offset,
-                    unterm.length,
-                    Arc::clone(&source_name),
-                    Arc::clone(&input),
-                ),
+                src: SpanWithSource::new(unterm.offset, unterm.length, source_name, input),
                 message,
                 label: Some("unterminated string literal".to_string()),
                 help: Some(
@@ -2096,19 +2084,14 @@ pub fn parse_idl_named(
         // from the original source text. This handles patterns that cannot
         // be detected from ANTLR error messages alone (e.g., empty unions,
         // misspelled keywords, fixed with non-integer size).
-        let refined = refine_errors_with_source(&collected_errors, &*input);
+        let refined = refine_errors_with_source(&collected_errors, input);
         let errors_to_report = refined.as_deref().unwrap_or(&collected_errors);
 
         let first = &errors_to_report[0];
         let related: Vec<ParseDiagnostic> = errors_to_report[1..]
             .iter()
             .map(|e| ParseDiagnostic {
-                src: SpanWithSource::new(
-                    e.offset,
-                    e.length,
-                    Arc::clone(&source_name),
-                    Arc::clone(&input),
-                ),
+                src: SpanWithSource::new(e.offset, e.length, source_name, input),
                 message: e.message.clone(),
                 label: e.label.clone(),
                 help: e.help.clone(),
@@ -2116,12 +2099,7 @@ pub fn parse_idl_named(
             })
             .collect();
         return Err(ParseDiagnostic {
-            src: SpanWithSource::new(
-                first.offset,
-                first.length,
-                Arc::clone(&source_name),
-                Arc::clone(&input),
-            ),
+            src: SpanWithSource::new(first.offset, first.length, source_name, input),
             message: first.message.clone(),
             label: first.label.clone(),
             help: first.help.clone(),
@@ -2137,8 +2115,8 @@ pub fn parse_idl_named(
     let token_stream = &parser.input;
 
     let src = SourceInfo {
-        source: Arc::clone(&input),
-        name: Arc::clone(&source_name),
+        source: input,
+        name: source_name,
         consumed_doc_indices: RefCell::new(HashSet::new()),
         warnings: RefCell::new(Vec::new()),
     };
@@ -2192,8 +2170,8 @@ type TS<'input> = CommonTokenStream<'input, IdlLexer<'input, InputStream<&'input
 /// Also tracks which doc comment token indices have been consumed by
 /// declarations, so that orphaned doc comments can be detected after the walk.
 struct SourceInfo {
-    source: Arc<str>,
-    name: Arc<str>,
+    source: &'static str,
+    name: &'static str,
     /// Token indices of doc comments consumed by `extract_doc_from_context`.
     /// After the full tree walk, any `DocComment` token NOT in this set is
     /// orphaned and should generate a warning.
@@ -2207,12 +2185,7 @@ struct SourceInfo {
 
 impl SourceInfo {
     fn span(&self, offset: usize, length: usize) -> SpanWithSource {
-        SpanWithSource::new(
-            offset,
-            length,
-            Arc::clone(&self.name),
-            Arc::clone(&self.source),
-        )
+        SpanWithSource::new(offset, length, self.name, self.source)
     }
 }
 
@@ -5384,7 +5357,7 @@ mod tests {
     // ------------------------------------------------------------------
 
     /// Helper: parse an IDL protocol with a single record, return its first field's schema.
-    fn parse_first_field_schema(idl: &str) -> AvroSchema {
+    fn parse_first_field_schema(idl: &'static str) -> AvroSchema {
         let (_idl_file, decl_items, _warnings) =
             parse_idl_for_test(idl).expect("IDL should parse successfully");
         // Find the record among declaration items.
@@ -5642,7 +5615,7 @@ mod tests {
 
     /// Helper: parse an IDL protocol and return the first named type schema
     /// (record, enum, or fixed).
-    fn parse_first_named_type(idl: &str) -> AvroSchema {
+    fn parse_first_named_type(idl: &'static str) -> AvroSchema {
         let (_idl_file, decl_items, _warnings) =
             parse_idl_for_test(idl).expect("IDL should parse successfully");
         for item in &decl_items {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -23,6 +23,7 @@
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use std::borrow::Borrow;
 
@@ -39,7 +40,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 use crate::doc_comments::extract_doc_comment;
-use crate::error::ParseDiagnostic;
+use crate::error::{ParseDiagnostic, SpanWithSource};
 use crate::generated::idllexer::IdlLexer;
 use crate::generated::idlparser::*;
 use crate::model::protocol::{Message, Protocol};
@@ -62,10 +63,8 @@ use miette::{Context, Result};
 /// the offending token underlined.
 pub(crate) struct Warning {
     pub(crate) message: String,
-    /// The source text and file name, for rich diagnostic rendering.
-    pub(crate) source: Option<miette::NamedSource<String>>,
-    /// Byte range of the token that triggered the warning.
-    pub(crate) span: Option<miette::SourceSpan>,
+    /// Source (file, source-code, offsets) of the problematic token
+    pub(crate) src: Option<SpanWithSource>,
 }
 
 /// Custom `Debug` implementation that shows a compact representation instead of
@@ -77,12 +76,13 @@ impl std::fmt::Debug for Warning {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Warning")
             .field("message", &self.message)
-            .field("file", &self.source.as_ref().map(|s| s.name().to_string()))
+            .field("file", &self.src.as_ref().map(|s| &*s.file_name))
             .field(
                 "span",
                 &self
-                    .span
-                    .map(|s| format!("{}..{}", s.offset(), s.offset() + s.len())),
+                    .src
+                    .as_ref()
+                    .map(|s| format!("{}..{}", s.offset, s.offset + s.length)),
             )
             .finish()
     }
@@ -100,7 +100,7 @@ impl Warning {
     fn out_of_place_doc_comment(
         line: isize,
         column: isize,
-        src: &SourceInfo<'_>,
+        src: &SourceInfo,
         token_start: isize,
         token_stop: isize,
     ) -> Self {
@@ -124,8 +124,7 @@ impl Warning {
                 // get_column() is 0-based, so we add 1 to match.
                 column + 1,
             ),
-            source: Some(miette::NamedSource::new(src.name, src.source.to_string())),
-            span: Some(miette::SourceSpan::new(offset.into(), length)),
+            src: Some(src.span(offset, length)),
         }
     }
 
@@ -137,7 +136,7 @@ impl Warning {
     /// warning lets the user know their annotations had no effect.
     fn annotations_dropped_on_union<'a>(
         annotation_keys: &[&str],
-        src: &SourceInfo<'_>,
+        src: &SourceInfo,
         ctx: &impl antlr4rust::parser_rule_context::ParserRuleContext<'a>,
     ) -> Self {
         let start_token = ctx.start();
@@ -164,8 +163,7 @@ impl Warning {
             message: format!(
                 "Annotations on union types are not supported and will be ignored: {keys_display}"
             ),
-            source: Some(miette::NamedSource::new(src.name, src.source.to_string())),
-            span: Some(miette::SourceSpan::new(byte_offset.into(), length)),
+            src: Some(src.span(byte_offset, length)),
         }
     }
 }
@@ -186,11 +184,11 @@ impl miette::Diagnostic for Warning {
     }
 
     fn source_code(&self) -> Option<&dyn miette::SourceCode> {
-        self.source.as_ref().map(|s| s as &dyn miette::SourceCode)
+        self.src.as_ref().map(|s| s as &dyn miette::SourceCode)
     }
 
     fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
-        let span = self.span?;
+        let sws = self.src.as_ref()?;
         // Derive a short label from the message content rather than hardcoding
         // a single label for all warning types.
         let label = if self.message.contains("out-of-place documentation comment") {
@@ -203,7 +201,7 @@ impl miette::Diagnostic for Warning {
             "here"
         };
         Some(Box::new(std::iter::once(
-            miette::LabeledSpan::new_with_span(Some(label.to_string()), span),
+            miette::LabeledSpan::new_with_span(Some(label.to_string()), sws.source_span()),
         )))
     }
 }
@@ -1800,7 +1798,7 @@ struct CollectingErrorListener {
     /// Original source text for line/column-to-byte-offset conversion.
     /// `None` for parser errors where the offending token always provides
     /// byte offsets directly.
-    source: Option<Rc<str>>,
+    source: Option<Arc<str>>,
 }
 
 impl<'a, T: Recognizer<'a>> ErrorListener<'a, T> for CollectingErrorListener {
@@ -1907,9 +1905,9 @@ pub enum IdlFile {
 pub struct ImportEntry {
     pub kind: ImportKind,
     pub path: String,
-    /// Byte range of the import statement in the originating IDL source,
+    /// Source location of the import statement in the originating IDL source,
     /// enabling source-highlighted diagnostics when import resolution fails.
-    pub span: Option<miette::SourceSpan>,
+    pub span: Option<SpanWithSource>,
 }
 
 /// The kind of import statement.
@@ -1930,20 +1928,20 @@ pub enum DeclItem {
     Import(ImportEntry),
     /// A locally-defined named type (record, enum, or fixed).
     ///
-    /// The optional `SourceSpan` records the byte range of the declaration in
-    /// the originating IDL source, enabling source-highlighted diagnostics when
-    /// registration fails (e.g., duplicate type name).
+    /// The optional `SpanWithSource` records the source location of the
+    /// declaration, enabling source-highlighted diagnostics when registration
+    /// fails (e.g., duplicate type name).
     ///
-    /// The `HashMap<String, SourceSpan>` maps field names to their default
-    /// value's source span for record types. When a field has a default value,
-    /// the span covers the `jsonValue` node; otherwise it falls back to the
-    /// `variableDeclaration` node. This enables per-field diagnostics that
+    /// The `HashMap<String, SpanWithSource>` maps field names to their default
+    /// value's source location for record types. When a field has a default
+    /// value, the span covers the `jsonValue` node; otherwise it falls back to
+    /// the `variableDeclaration` node. This enables per-field diagnostics that
     /// highlight the offending default value when validating Reference-typed
     /// fields in the compiler.
     Type(
         Box<AvroSchema>,
-        Option<miette::SourceSpan>,
-        HashMap<String, miette::SourceSpan>,
+        Option<SpanWithSource>,
+        HashMap<String, SpanWithSource>,
     ),
 }
 
@@ -1964,14 +1962,14 @@ pub fn parse_idl_for_test(input: &str) -> Result<(IdlFile, Vec<DeclItem>, Vec<Wa
         input
     };
 
-    parse_idl_named(input, "<input>")
+    parse_idl_named(Arc::from(input), Arc::from("<input>"))
 }
 
 /// Parse an Avro IDL string, attaching `source_name` to any error diagnostics
 /// so that error messages identify the originating file.
 pub fn parse_idl_named(
-    input: &str,
-    source_name: &str,
+    input: Arc<str>,
+    source_name: Arc<str>,
 ) -> Result<(IdlFile, Vec<DeclItem>, Vec<Warning>)> {
     // The ANTLR grammar's `idlFile` rule includes `('\u001a' .*?)? EOF`
     // to treat the ASCII SUB character (U+001A) as an end-of-file marker,
@@ -1979,11 +1977,12 @@ pub fn parse_idl_named(
     // this correctly, so we strip the SUB character and everything after it
     // before passing the input to the lexer.
     let input = if let Some(pos) = input.find('\u{001a}') {
-        &input[..pos]
+        let stripped = &(*input)[..pos];
+        Arc::from(stripped)
     } else {
         input
     };
-    let input_stream = InputStream::new(input);
+    let input_stream = InputStream::new(&*input);
     let mut lexer = IdlLexer::new(input_stream);
 
     // Replace the lexer's default ConsoleErrorListener with a
@@ -1992,12 +1991,11 @@ pub fn parse_idl_named(
     // warnings instead, matching Java's behavior of not treating lexer
     // errors as fatal. (Java also doesn't install a custom listener on
     // the lexer — it just lets ConsoleErrorListener print to stderr.)
-    let source_rc: Rc<str> = Rc::from(input);
     let lexer_errors: Rc<RefCell<Vec<SyntaxError>>> = Rc::new(RefCell::new(Vec::new()));
     lexer.remove_error_listeners();
     lexer.add_error_listener(Box::new(CollectingErrorListener {
         errors: Rc::clone(&lexer_errors),
-        source: Some(Rc::clone(&source_rc)),
+        source: Some(Arc::clone(&input)),
     }));
 
     let token_stream = CommonTokenStream::new(lexer);
@@ -2034,8 +2032,12 @@ pub fn parse_idl_named(
         .iter()
         .map(|e| Warning {
             message: e.message.clone(),
-            source: Some(miette::NamedSource::new(source_name, input.to_string())),
-            span: Some(miette::SourceSpan::new(e.offset.into(), e.length)),
+            src: Some(SpanWithSource::new(
+                e.offset,
+                e.length,
+                Arc::clone(&source_name),
+                Arc::clone(&input),
+            )),
         })
         .collect();
 
@@ -2073,8 +2075,12 @@ pub fn parse_idl_named(
             };
 
             return Err(ParseDiagnostic {
-                src: miette::NamedSource::new(source_name, input.to_string()),
-                span: miette::SourceSpan::new(unterm.offset.into(), unterm.length),
+                src: SpanWithSource::new(
+                    unterm.offset,
+                    unterm.length,
+                    Arc::clone(&source_name),
+                    Arc::clone(&input),
+                ),
                 message,
                 label: Some("unterminated string literal".to_string()),
                 help: Some(
@@ -2090,15 +2096,19 @@ pub fn parse_idl_named(
         // from the original source text. This handles patterns that cannot
         // be detected from ANTLR error messages alone (e.g., empty unions,
         // misspelled keywords, fixed with non-integer size).
-        let refined = refine_errors_with_source(&collected_errors, input);
+        let refined = refine_errors_with_source(&collected_errors, &*input);
         let errors_to_report = refined.as_deref().unwrap_or(&collected_errors);
 
         let first = &errors_to_report[0];
         let related: Vec<ParseDiagnostic> = errors_to_report[1..]
             .iter()
             .map(|e| ParseDiagnostic {
-                src: miette::NamedSource::new(source_name, input.to_string()),
-                span: miette::SourceSpan::new(e.offset.into(), e.length),
+                src: SpanWithSource::new(
+                    e.offset,
+                    e.length,
+                    Arc::clone(&source_name),
+                    Arc::clone(&input),
+                ),
                 message: e.message.clone(),
                 label: e.label.clone(),
                 help: e.help.clone(),
@@ -2106,8 +2116,12 @@ pub fn parse_idl_named(
             })
             .collect();
         return Err(ParseDiagnostic {
-            src: miette::NamedSource::new(source_name, input.to_string()),
-            span: miette::SourceSpan::new(first.offset.into(), first.length),
+            src: SpanWithSource::new(
+                first.offset,
+                first.length,
+                Arc::clone(&source_name),
+                Arc::clone(&input),
+            ),
             message: first.message.clone(),
             label: first.label.clone(),
             help: first.help.clone(),
@@ -2123,8 +2137,8 @@ pub fn parse_idl_named(
     let token_stream = &parser.input;
 
     let src = SourceInfo {
-        source: input,
-        name: source_name,
+        source: Arc::clone(&input),
+        name: Arc::clone(&source_name),
         consumed_doc_indices: RefCell::new(HashSet::new()),
         warnings: RefCell::new(Vec::new()),
     };
@@ -2177,9 +2191,9 @@ type TS<'input> = CommonTokenStream<'input, IdlLexer<'input, InputStream<&'input
 ///
 /// Also tracks which doc comment token indices have been consumed by
 /// declarations, so that orphaned doc comments can be detected after the walk.
-struct SourceInfo<'a> {
-    source: &'a str,
-    name: &'a str,
+struct SourceInfo {
+    source: Arc<str>,
+    name: Arc<str>,
     /// Token indices of doc comments consumed by `extract_doc_from_context`.
     /// After the full tree walk, any `DocComment` token NOT in this set is
     /// orphaned and should generate a warning.
@@ -2189,6 +2203,17 @@ struct SourceInfo<'a> {
     /// push here rather than threading `&mut Vec<Warning>` through every
     /// call site.
     warnings: RefCell<Vec<Warning>>,
+}
+
+impl SourceInfo {
+    fn span(&self, offset: usize, length: usize) -> SpanWithSource {
+        SpanWithSource::new(
+            offset,
+            length,
+            Arc::clone(&self.name),
+            Arc::clone(&self.source),
+        )
+    }
 }
 
 /// Compute `(offset, length)` from ANTLR's inclusive start/stop byte offsets.
@@ -2215,7 +2240,7 @@ fn span_from_offsets(start: isize, stop: isize) -> (usize, usize) {
 /// `SourceSpan` that miette can render as an underlined region in the error
 /// output.
 fn make_diagnostic<'input>(
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
     ctx: &impl antlr4rust::parser_rule_context::ParserRuleContext<'input>,
     message: impl Into<String>,
 ) -> miette::Report {
@@ -2240,8 +2265,7 @@ fn make_diagnostic<'input>(
 
     let message = message.into();
     ParseDiagnostic {
-        src: miette::NamedSource::new(src.name, src.source.to_string()),
-        span: miette::SourceSpan::new(offset.into(), length),
+        src: src.span(offset, length),
         message,
         label: None,
         help: None,
@@ -2254,7 +2278,7 @@ fn make_diagnostic<'input>(
 /// context node. Useful when the error relates to a specific token field
 /// (e.g. `ctx.size`, `ctx.typeName`) rather than the whole context.
 fn make_diagnostic_from_token(
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
     token: &impl Token,
     message: impl Into<String>,
 ) -> miette::Report {
@@ -2262,8 +2286,7 @@ fn make_diagnostic_from_token(
 
     let message = message.into();
     ParseDiagnostic {
-        src: miette::NamedSource::new(src.name, src.source.to_string()),
-        span: miette::SourceSpan::new(offset.into(), length),
+        src: src.span(offset, length),
         message,
         label: None,
         help: None,
@@ -2280,13 +2303,13 @@ fn make_diagnostic_from_token(
 /// source-highlighted diagnostics.
 fn span_from_context<'input>(
     ctx: &impl antlr4rust::parser_rule_context::ParserRuleContext<'input>,
-) -> Option<miette::SourceSpan> {
+) -> Option<(usize, usize)> {
     let start_token = ctx.start();
     let (offset, length) = span_from_offsets(start_token.get_start(), start_token.get_stop());
 
     // A zero-length span at offset 0 means no valid position was available.
     if length > 0 {
-        Some(miette::SourceSpan::new(offset.into(), length))
+        Some((offset, length))
     } else {
         None
     }
@@ -2472,7 +2495,7 @@ const MESSAGE_PROPS: PropertyContext = PropertyContext {
 fn walk_schema_properties<'input>(
     props: &[Rc<SchemaPropertyContextAll<'input>>],
     token_stream: &TS<'input>,
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
     pctx: PropertyContext,
 ) -> Result<SchemaProperties> {
     let mut result = SchemaProperties::new();
@@ -2592,7 +2615,7 @@ fn walk_schema_properties<'input>(
 fn walk_idl_file<'input>(
     ctx: &IdlFileContextAll<'input>,
     token_stream: &TS<'input>,
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
     namespace: &mut Option<String>,
     decl_items: &mut Vec<DeclItem>,
 ) -> Result<IdlFile> {
@@ -2625,9 +2648,9 @@ fn walk_idl_file<'input>(
             .clone()
             .downcast_rc::<ImportStatementContextAll<'input>>()
         {
-            collect_single_import(&import_ctx, decl_items);
+            collect_single_import(&import_ctx, decl_items, src);
         } else if let Ok(ns_ctx) = child.downcast_rc::<NamedSchemaDeclarationContextAll<'input>>() {
-            let span = span_from_context(&*ns_ctx);
+            let span = span_from_context(&*ns_ctx).map(|(o, l)| src.span(o, l));
             let (schema, field_spans) =
                 walk_named_schema_no_register(&ns_ctx, token_stream, src, namespace)?;
             local_schemas.push(schema.clone());
@@ -2661,7 +2684,7 @@ fn walk_idl_file<'input>(
 fn walk_protocol<'input>(
     ctx: &ProtocolDeclarationContextAll<'input>,
     token_stream: &TS<'input>,
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
     namespace: &mut Option<String>,
     decl_items: &mut Vec<DeclItem>,
 ) -> Result<Protocol> {
@@ -2710,12 +2733,12 @@ fn walk_protocol<'input>(
             .clone()
             .downcast_rc::<ImportStatementContextAll<'input>>()
         {
-            collect_single_import(&import_ctx, decl_items);
+            collect_single_import(&import_ctx, decl_items, src);
         } else if let Ok(ns_ctx) = child
             .clone()
             .downcast_rc::<NamedSchemaDeclarationContextAll<'input>>()
         {
-            let span = span_from_context(&*ns_ctx);
+            let span = span_from_context(&*ns_ctx).map(|(o, l)| src.span(o, l));
             let (schema, field_spans) =
                 walk_named_schema_no_register(&ns_ctx, token_stream, src, namespace)?;
             decl_items.push(DeclItem::Type(Box::new(schema), span, field_spans));
@@ -2746,9 +2769,9 @@ fn walk_protocol<'input>(
 fn walk_named_schema_no_register<'input>(
     ctx: &NamedSchemaDeclarationContextAll<'input>,
     token_stream: &TS<'input>,
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
     namespace: &mut Option<String>,
-) -> Result<(AvroSchema, HashMap<String, miette::SourceSpan>)> {
+) -> Result<(AvroSchema, HashMap<String, SpanWithSource>)> {
     if let Some(fixed_ctx) = ctx.fixedDeclaration() {
         Ok((
             walk_fixed(&fixed_ctx, token_stream, src, namespace.as_deref())?,
@@ -2782,9 +2805,9 @@ fn walk_named_schema_no_register<'input>(
 fn walk_record<'input>(
     ctx: &RecordDeclarationContextAll<'input>,
     token_stream: &TS<'input>,
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
     namespace: &mut Option<String>,
-) -> Result<(AvroSchema, HashMap<String, miette::SourceSpan>)> {
+) -> Result<(AvroSchema, HashMap<String, SpanWithSource>)> {
     let doc = extract_doc_from_context(ctx, token_stream, src);
     let props = walk_schema_properties(
         &ctx.schemaProperty_all(),
@@ -2831,7 +2854,7 @@ fn walk_record<'input>(
         .ok_or_else(|| make_diagnostic(src, ctx, "missing record body"))?;
 
     let mut fields = Vec::new();
-    let mut field_spans: HashMap<String, miette::SourceSpan> = HashMap::new();
+    let mut field_spans: HashMap<String, SpanWithSource> = HashMap::new();
     let mut seen_field_names: HashSet<String> = HashSet::new();
     for field_ctx in body.fieldDeclaration_all() {
         let mut field_fields = walk_field_declaration(
@@ -2878,8 +2901,8 @@ fn walk_record<'input>(
                 .jsonValue()
                 .and_then(|jv| span_from_context(&*jv))
                 .or_else(|| span_from_context(&**var_ctx));
-            if let Some(span) = default_span {
-                field_spans.insert(field.name.clone(), span);
+            if let Some((offset, length)) = default_span {
+                field_spans.insert(field.name.clone(), src.span(offset, length));
             }
         }
         fields.append(&mut field_fields);
@@ -2914,7 +2937,7 @@ fn walk_record<'input>(
 fn walk_field_declaration<'input>(
     ctx: &FieldDeclarationContextAll<'input>,
     token_stream: &TS<'input>,
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
     namespace: Option<&str>,
     enclosing_name: Option<&str>,
 ) -> Result<Vec<Field>> {
@@ -2955,7 +2978,7 @@ fn walk_variable<'input>(
     field_type: &AvroSchema,
     default_doc: Option<&str>,
     token_stream: &TS<'input>,
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
     _namespace: Option<&str>,
     enclosing_name: Option<&str>,
 ) -> Result<Field> {
@@ -3037,7 +3060,7 @@ fn walk_variable<'input>(
 fn walk_enum<'input>(
     ctx: &EnumDeclarationContextAll<'input>,
     token_stream: &TS<'input>,
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
     enclosing_namespace: Option<&str>,
 ) -> Result<AvroSchema> {
     let doc = extract_doc_from_context(ctx, token_stream, src);
@@ -3121,7 +3144,7 @@ fn walk_enum<'input>(
 fn walk_fixed<'input>(
     ctx: &FixedDeclarationContextAll<'input>,
     token_stream: &TS<'input>,
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
     enclosing_namespace: Option<&str>,
 ) -> Result<AvroSchema> {
     let doc = extract_doc_from_context(ctx, token_stream, src);
@@ -3189,7 +3212,7 @@ fn walk_fixed<'input>(
 fn walk_full_type<'input>(
     ctx: &FullTypeContextAll<'input>,
     token_stream: &TS<'input>,
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
     namespace: Option<&str>,
 ) -> Result<AvroSchema> {
     let props = walk_schema_properties(&ctx.schemaProperty_all(), token_stream, src, BARE_PROPS)?;
@@ -3241,7 +3264,7 @@ fn walk_full_type<'input>(
 fn walk_plain_type<'input>(
     ctx: &PlainTypeContextAll<'input>,
     token_stream: &TS<'input>,
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
     namespace: Option<&str>,
 ) -> Result<AvroSchema> {
     if let Some(array_ctx) = ctx.arrayType() {
@@ -3264,7 +3287,7 @@ fn walk_plain_type<'input>(
 fn walk_nullable_type<'input>(
     ctx: &NullableTypeContextAll<'input>,
     _token_stream: &TS<'input>,
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
     namespace: Option<&str>,
 ) -> Result<AvroSchema> {
     let base_type = if let Some(prim_ctx) = ctx.primitiveType() {
@@ -3274,7 +3297,7 @@ fn walk_nullable_type<'input>(
         // so the Reference carries them separately, enabling correct namespace
         // shortening during JSON serialization.
         let type_name = identifier_text(&ref_ctx);
-        let ref_span = span_from_context(&*ref_ctx);
+        let ref_span = span_from_context(&*ref_ctx).map(|(o, l)| src.span(o, l));
         if let Some((ns, name)) = type_name.rsplit_once('.') {
             AvroSchema::Reference {
                 name: name.to_string(),
@@ -3317,7 +3340,7 @@ fn walk_nullable_type<'input>(
 /// Walk a primitive type keyword and return the corresponding `AvroSchema`.
 fn walk_primitive_type<'input>(
     ctx: &PrimitiveTypeContextAll<'input>,
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
 ) -> Result<AvroSchema> {
     let type_tok = ctx
         .typeName
@@ -3425,7 +3448,7 @@ fn walk_primitive_type<'input>(
 fn walk_array_type<'input>(
     ctx: &ArrayTypeContextAll<'input>,
     token_stream: &TS<'input>,
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
     namespace: Option<&str>,
 ) -> Result<AvroSchema> {
     let element_ctx = ctx
@@ -3442,7 +3465,7 @@ fn walk_array_type<'input>(
 fn walk_map_type<'input>(
     ctx: &MapTypeContextAll<'input>,
     token_stream: &TS<'input>,
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
     namespace: Option<&str>,
 ) -> Result<AvroSchema> {
     let value_ctx = ctx
@@ -3459,7 +3482,7 @@ fn walk_map_type<'input>(
 fn walk_union_type<'input>(
     ctx: &UnionTypeContextAll<'input>,
     token_stream: &TS<'input>,
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
     namespace: Option<&str>,
 ) -> Result<AvroSchema> {
     let mut types = Vec::new();
@@ -3511,7 +3534,7 @@ fn walk_union_type<'input>(
 fn walk_message<'input>(
     ctx: &MessageDeclarationContextAll<'input>,
     token_stream: &TS<'input>,
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
     namespace: Option<&str>,
 ) -> Result<(String, Message)> {
     let doc = extract_doc_from_context(ctx, token_stream, src);
@@ -3599,7 +3622,7 @@ fn walk_message<'input>(
         let mut error_schemas = Vec::new();
         for error_id_ctx in &ctx.errors {
             let error_name = identifier_text(error_id_ctx);
-            let error_span = span_from_context(&**error_id_ctx);
+            let error_span = span_from_context(&**error_id_ctx).map(|(o, l)| src.span(o, l));
             if let Some((ns, name)) = error_name.rsplit_once('.') {
                 error_schemas.push(AvroSchema::Reference {
                     name: name.to_string(),
@@ -3644,7 +3667,7 @@ fn walk_message<'input>(
 fn walk_result_type<'input>(
     ctx: &ResultTypeContextAll<'input>,
     token_stream: &TS<'input>,
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
     namespace: Option<&str>,
 ) -> Result<AvroSchema> {
     // If there's a Void token, return Null.
@@ -3666,7 +3689,7 @@ fn walk_result_type<'input>(
 fn walk_json_value<'input>(
     ctx: &JsonValueContextAll<'input>,
     token_stream: &TS<'input>,
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
 ) -> Result<Value> {
     if let Some(obj_ctx) = ctx.jsonObject() {
         return walk_json_object(&obj_ctx, token_stream, src);
@@ -3682,7 +3705,7 @@ fn walk_json_value<'input>(
 
 fn walk_json_literal<'input>(
     ctx: &JsonLiteralContextAll<'input>,
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
 ) -> Result<Value> {
     let tok = ctx
         .literal
@@ -3720,7 +3743,7 @@ fn walk_json_literal<'input>(
 fn walk_json_object<'input>(
     ctx: &JsonObjectContextAll<'input>,
     token_stream: &TS<'input>,
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
 ) -> Result<Value> {
     let mut map = serde_json::Map::new();
     for pair_ctx in ctx.jsonPair_all() {
@@ -3743,7 +3766,7 @@ fn walk_json_object<'input>(
 fn walk_json_array<'input>(
     ctx: &JsonArrayContextAll<'input>,
     token_stream: &TS<'input>,
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
 ) -> Result<Value> {
     let mut elements = Vec::new();
     for val_ctx in ctx.jsonValue_all() {
@@ -4430,7 +4453,7 @@ fn json_value_as_u32(v: &Value) -> Option<u32> {
 fn extract_doc_from_context<'input, T>(
     ctx: &T,
     token_stream: &TS<'input>,
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
 ) -> Option<String>
 where
     T: antlr4rust::parser_rule_context::ParserRuleContext<'input>,
@@ -4455,7 +4478,7 @@ where
 fn collect_orphaned_doc_comment_warnings<'input, S>(
     token_stream: &S,
     consumed_indices: &HashSet<isize>,
-    src: &SourceInfo<'_>,
+    src: &SourceInfo,
 ) -> Vec<Warning>
 where
     S: TokenStream<'input>,
@@ -4487,6 +4510,7 @@ where
 fn collect_single_import<'input>(
     import_ctx: &ImportStatementContextAll<'input>,
     decl_items: &mut Vec<DeclItem>,
+    src: &SourceInfo,
 ) {
     let kind_tok = import_ctx.importType.as_ref();
     let location_tok = import_ctx.location.as_ref();
@@ -4502,7 +4526,7 @@ fn collect_single_import<'input>(
         decl_items.push(DeclItem::Import(ImportEntry {
             kind: import_kind,
             path: get_string_from_literal(loc.get_text()),
-            span: span_from_context(import_ctx),
+            span: span_from_context(import_ctx).map(|(o, l)| src.span(o, l)),
         }));
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -75,7 +75,7 @@ impl std::fmt::Debug for Warning {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Warning")
             .field("message", &self.message)
-            .field("file", &self.span.as_ref().map(|s| s.file_name))
+            .field("file", &self.span.as_ref().map(|s| s.name))
             .field(
                 "span",
                 &self

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -15,8 +15,8 @@
 // named type.
 
 use indexmap::IndexMap;
-use miette::SourceSpan;
 
+use crate::error::SpanWithSource;
 use crate::model::schema::{AvroSchema, make_full_name};
 
 // ==============================================================================
@@ -185,7 +185,7 @@ impl SchemaRegistry {
     ///
     /// The caller is responsible for deduplication and ordering -- see
     /// `validate_all_references` in `compiler.rs`.
-    pub fn validate_references(&self) -> Vec<(String, Option<SourceSpan>)> {
+    pub fn validate_references(&self) -> Vec<(String, Option<SpanWithSource>)> {
         let mut unresolved = Vec::new();
         for schema in self.schemas.values() {
             collect_unresolved_refs(schema, &self.schemas, &mut unresolved);
@@ -205,7 +205,10 @@ impl SchemaRegistry {
     ///
     /// The caller is responsible for deduplication and ordering -- see
     /// `validate_all_references` in `compiler.rs`.
-    pub fn validate_schema(&self, schema: &AvroSchema) -> Vec<(String, Option<SourceSpan>)> {
+    pub fn validate_schema(
+        &self,
+        schema: &AvroSchema,
+    ) -> Vec<(String, Option<SpanWithSource>)> {
         let mut unresolved = Vec::new();
         collect_unresolved_refs(schema, &self.schemas, &mut unresolved);
         unresolved
@@ -225,7 +228,7 @@ impl SchemaRegistry {
 fn collect_unresolved_refs(
     schema: &AvroSchema,
     known: &IndexMap<String, AvroSchema>,
-    unresolved: &mut Vec<(String, Option<SourceSpan>)>,
+    unresolved: &mut Vec<(String, Option<SpanWithSource>)>,
 ) {
     match schema {
         AvroSchema::Reference {
@@ -236,7 +239,7 @@ fn collect_unresolved_refs(
         } => {
             let full_name = make_full_name(name, namespace.as_deref());
             if !known.contains_key(full_name.as_ref()) {
-                unresolved.push((full_name.into_owned(), *span));
+                unresolved.push((full_name.into_owned(), span.clone()));
             }
         }
         AvroSchema::Record { fields, .. } => {
@@ -274,7 +277,7 @@ mod tests {
 
     /// Extract just the names from unresolved reference tuples, for concise
     /// test assertions.
-    fn names(unresolved: Vec<(String, Option<SourceSpan>)>) -> Vec<String> {
+    fn names(unresolved: Vec<(String, Option<SpanWithSource>)>) -> Vec<String> {
         unresolved.into_iter().map(|(name, _)| name).collect()
     }
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -236,7 +236,7 @@ fn collect_unresolved_refs(
         } => {
             let full_name = make_full_name(name, namespace.as_deref());
             if !known.contains_key(full_name.as_ref()) {
-                unresolved.push((full_name.into_owned(), span.clone()));
+                unresolved.push((full_name.into_owned(), *span));
             }
         }
         AvroSchema::Record { fields, .. } => {

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -205,10 +205,7 @@ impl SchemaRegistry {
     ///
     /// The caller is responsible for deduplication and ordering -- see
     /// `validate_all_references` in `compiler.rs`.
-    pub fn validate_schema(
-        &self,
-        schema: &AvroSchema,
-    ) -> Vec<(String, Option<SpanWithSource>)> {
+    pub fn validate_schema(&self, schema: &AvroSchema) -> Vec<(String, Option<SpanWithSource>)> {
         let mut unresolved = Vec::new();
         collect_unresolved_refs(schema, &self.schemas, &mut unresolved);
         unresolved

--- a/tests/error_reporting.rs
+++ b/tests/error_reporting.rs
@@ -29,7 +29,7 @@ use miette::{Diagnostic, GraphicalReportHandler, GraphicalTheme};
 /// output for errors without source location info.
 ///
 /// Returns `None` if compilation succeeds.
-fn compile_error(input: &str) -> Option<String> {
+fn compile_error(input: &'static str) -> Option<String> {
     compile_error_with_width(input, 80)
 }
 
@@ -38,7 +38,7 @@ fn compile_error(input: &str) -> Option<String> {
 /// Useful when error messages embed absolute paths that would be split across
 /// lines at the default 80-column width, making post-processing (e.g., CWD
 /// redaction) unreliable.
-fn compile_error_with_width(input: &str, width: usize) -> Option<String> {
+fn compile_error_with_width(input: &'static str, width: usize) -> Option<String> {
     match Idl::new().convert_str(input) {
         Ok(_) => None,
         Err(e) => {
@@ -84,7 +84,7 @@ fn compile_file_error(path: &std::path::Path) -> Option<String> {
 /// compilation.
 ///
 /// Panics if compilation fails, since warning tests require a successful parse.
-fn compile_warnings(input: &str) -> Vec<miette::Report> {
+fn compile_warnings(input: &'static str) -> Vec<miette::Report> {
     let output = Idl::new()
         .convert_str(input)
         .expect("warning test input should compile successfully");

--- a/tests/error_reporting.rs
+++ b/tests/error_reporting.rs
@@ -320,6 +320,49 @@ fn test_error_import_bad_avpr_json() {
     insta::assert_snapshot!(error);
 }
 
+/// Referencing an unkown type should produce an error that
+/// includes the source span of the `unknown.type` in the calling `.avdl`
+/// file.
+#[test]
+#[cfg_attr(windows, ignore)]
+fn test_error_file_unknown_type() {
+    let avdl_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/testdata/test_import_unknown_type.avdl");
+    let error = compile_file_error(&avdl_path).expect("should produce an error for unknown type");
+
+    // Redact the absolute path prefix so the snapshot is portable.
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let error = error.replace(manifest_dir, "[ROOT]");
+    insta::assert_snapshot!(error);
+
+    assert!(
+        error.contains("unknown_type.avdl"),
+        "error should mention the imported file containing the syntax error"
+    );
+}
+
+/// Importing a `.avdl` file with a syntax error should produce an error that
+/// includes the source span of the syntax error in the imported file, and
+/// mentions both the calling file and the imported file.
+#[test]
+#[cfg_attr(windows, ignore)]
+fn test_error_import_syntax_error() {
+    let avdl_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/testdata/test_import_syntax_error.avdl");
+    let error = compile_file_error(&avdl_path)
+        .expect("should produce an error for syntax error in imported file");
+
+    // Redact the absolute path prefix so the snapshot is portable.
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let error = error.replace(manifest_dir, "[ROOT]");
+    insta::assert_snapshot!(error);
+
+    assert!(
+        error.contains("syntax_error.avdl"),
+        "error should mention the imported file containing the syntax error"
+    );
+}
+
 // ==============================================================================
 // Mutation Error Tests (Slight Variations of Valid IDL)
 // ==============================================================================

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -602,7 +602,7 @@ fn test_extra_schema_syntax() {
 // ==============================================================================
 
 /// Helper: parse an inline `.avdl` string via the builder and return JSON.
-fn parse_inline_to_json(avdl_input: &str) -> Value {
+fn parse_inline_to_json(avdl_input: &'static str) -> Value {
     let output = Idl::new()
         .convert_str(avdl_input)
         .unwrap_or_else(|e| panic!("failed to parse inline avdl: {e}"));

--- a/tests/snapshots/error_reporting__error_file_unknown_type.snap
+++ b/tests/snapshots/error_reporting__error_file_unknown_type.snap
@@ -1,0 +1,12 @@
+---
+source: tests/error_reporting.rs
+expression: error
+---
+  x Undefined name: unknown.type
+   ,-[[ROOT]/tests/testdata/unknown_type.avdl:3:5]
+ 2 |   record Foo {
+ 3 |     unknown.type field;
+   :     ^^^^^^|^^^^^
+   :           `-- Undefined name: unknown.type
+ 4 |   }
+   `----

--- a/tests/snapshots/error_reporting__error_import_syntax_error.snap
+++ b/tests/snapshots/error_reporting__error_import_syntax_error.snap
@@ -1,0 +1,13 @@
+---
+source: tests/error_reporting.rs
+expression: error
+---
+  x parse imported IDL [ROOT]/tests/testdata/syntax_error.avdl
+  `-> line 6:2 unexpected '}' expected ';' or ','
+   ,-[[ROOT]/tests/testdata/syntax_error.avdl:6:3]
+ 5 |     string name
+ 6 |   }
+   :   |
+   :   `-- line 6:2 unexpected '}' expected ';' or ','
+ 7 | }
+   `----

--- a/tests/testdata/syntax_error.avdl
+++ b/tests/testdata/syntax_error.avdl
@@ -1,0 +1,7 @@
+@namespace("test.error")
+protocol SyntaxError {
+  // Missing semicolon after field declaration
+  record BadRecord {
+    string name
+  }
+}

--- a/tests/testdata/test_import_syntax_error.avdl
+++ b/tests/testdata/test_import_syntax_error.avdl
@@ -1,0 +1,8 @@
+@namespace("test")
+protocol ImportError {
+  import idl "syntax_error.avdl";
+
+  record MyRecord {
+    string value;
+  }
+}

--- a/tests/testdata/test_import_unknown_type.avdl
+++ b/tests/testdata/test_import_unknown_type.avdl
@@ -1,0 +1,8 @@
+@namespace("test")
+protocol ImportError {
+  import idl "unknown_type.avdl";
+
+  record MyRecord {
+    string value;
+  }
+}

--- a/tests/testdata/unknown_type.avdl
+++ b/tests/testdata/unknown_type.avdl
@@ -1,0 +1,6 @@
+protocol Test {
+  record Foo {
+    unknown.type field;
+  }
+}
+


### PR DESCRIPTION


`Reference`s used to store a Span, which is later connected with the source and source_name of the root-file, giving confusing diagnostics for errors in imported files. The first commit adds a test to show this.
The 2nd commit fixes it by making Arc's of source and source_name available throughout the visitor, stores those in the `Reference`s so they can be used to generate Warnings