### PR TITLE
test doc comments in all possible positions

### DIFF
--- a/tests/error_reporting.rs
+++ b/tests/error_reporting.rs
@@ -245,21 +245,74 @@ fn test_warning_out_of_place_doc_comment() {
 }
 
 /// Multiple out-of-place doc comments should each generate a separate warning.
+///
+/// Covers every grammar node that accepts a `(doc=DocComment)?` clause:
+/// - `protocolDeclaration`, `recordDeclaration` (record + error), `fixedDeclaration`,
+///   `enumDeclaration`, `enumSymbol`, `fieldDeclaration`, `variableDeclaration`,
+///   `messageDeclaration`, `formalParameter`.
+///
+/// USED comments are placed in the correct syntactic position and consumed by the
+/// walker.  ORPHAN comments are either (a) in trailing positions that no grammar
+/// rule consumes, or (b) on `enumSymbol` nodes, which the walker never reads docs
+/// for because Avro schema JSON has no per-symbol doc field :( .
 #[test]
 fn test_warning_multiple_out_of_place_doc_comments() {
     let input = r#"
+        /** USED protocol doc */
         @namespace("test")
+        /** ORPHAN between namespace and protocol */
         protocol P {
-            /** orphan 1 */
+            /** USED record doc */
             record R {
+                /** USED field-decl doc */
                 string name;
-                /** orphan 2 */
+
+                int /** USED in-field-decl doc */ age;
+
+                boolean active;
+                /** ORPHAN trailing in record body */
             }
-            /** orphan 3 */
+
+            /** USED error doc */
+            error RpcError {
+                /** USED error field doc */
+                string message;
+                /** ORPHAN trailing in error body */
+            }
+
+            /** USED fixed doc */
+            fixed MD5(16);
+
+            /** USED enum doc */
+            enum Status {
+                /** ORPHAN enum symbol doc (!) */
+                PENDING,
+                DONE
+                /** ORPHAN trailing in enum body */
+            }
+
+            /** USED message doc */
+            void ping(/** USED param doc */ R arg) throws RpcError;
+
+            /** ORPHAN trailing in protocol body */
         }
+        /** ORPHAN after protocol closing brace */
     "#;
+
     let warnings = compile_warnings(input);
     insta::assert_snapshot!(render_diagnostics(&warnings));
+    assert_eq!(warnings.len(), 7);
+    warnings.iter().for_each(|w| {
+        let rendered = format!("{w:?}");
+        assert!(
+            rendered.contains("ORPHAN"),
+            "should only warn about 'ORPHAN' comments, {rendered}"
+        );
+        assert!(
+            !rendered.contains("USED"),
+            "should not warn about 'USED' comments, {rendered}"
+        );
+    });
 }
 
 // ==============================================================================

--- a/tests/snapshots/error_reporting__warning_multiple_out_of_place_doc_comments.snap
+++ b/tests/snapshots/error_reporting__warning_multiple_out_of_place_doc_comments.snap
@@ -1,23 +1,74 @@
 ---
 source: tests/error_reporting.rs
+assertion_line: 303
 expression: render_diagnostics(&warnings)
 ---
-  ! Line 7, char 17: Ignoring out-of-place documentation comment.
+  ! Line 4, char 9: Ignoring out-of-place documentation comment.
   | Did you mean to use a multiline comment ( /* ... */ ) instead?
-   ,-[<input>:7:17]
- 6 |                 string name;
- 7 |                 /** orphan 2 */
-   :                 ^^^^^^^|^^^^^^^
-   :                        `-- out-of-place doc comment
- 8 |             }
+   ,-[<input>:4:9]
+ 3 |         @namespace("test")
+ 4 |         /** ORPHAN between namespace and protocol */
+   :         ^^^^^^^^^^^^^^^^^^^^^^|^^^^^^^^^^^^^^^^^^^^^
+   :                               `-- out-of-place doc comment
+ 5 |         protocol P {
    `----
 
-  ! Line 9, char 13: Ignoring out-of-place documentation comment.
+  ! Line 14, char 17: Ignoring out-of-place documentation comment.
   | Did you mean to use a multiline comment ( /* ... */ ) instead?
-    ,-[<input>:9:13]
-  8 |             }
-  9 |             /** orphan 3 */
-    :             ^^^^^^^|^^^^^^^
-    :                    `-- out-of-place doc comment
- 10 |         }
+    ,-[<input>:14:17]
+ 13 |                 boolean active;
+ 14 |                 /** ORPHAN trailing in record body */
+    :                 ^^^^^^^^^^^^^^^^^^|^^^^^^^^^^^^^^^^^^
+    :                                   `-- out-of-place doc comment
+ 15 |             }
+    `----
+
+  ! Line 21, char 17: Ignoring out-of-place documentation comment.
+  | Did you mean to use a multiline comment ( /* ... */ ) instead?
+    ,-[<input>:21:17]
+ 20 |                 string message;
+ 21 |                 /** ORPHAN trailing in error body */
+    :                 ^^^^^^^^^^^^^^^^^^|^^^^^^^^^^^^^^^^^
+    :                                   `-- out-of-place doc comment
+ 22 |             }
+    `----
+
+  ! Line 29, char 17: Ignoring out-of-place documentation comment.
+  | Did you mean to use a multiline comment ( /* ... */ ) instead?
+    ,-[<input>:29:17]
+ 28 |             enum Status {
+ 29 |                 /** ORPHAN enum symbol doc (!) */
+    :                 ^^^^^^^^^^^^^^^^|^^^^^^^^^^^^^^^^
+    :                                 `-- out-of-place doc comment
+ 30 |                 PENDING,
+    `----
+
+  ! Line 32, char 17: Ignoring out-of-place documentation comment.
+  | Did you mean to use a multiline comment ( /* ... */ ) instead?
+    ,-[<input>:32:17]
+ 31 |                 DONE
+ 32 |                 /** ORPHAN trailing in enum body */
+    :                 ^^^^^^^^^^^^^^^^^|^^^^^^^^^^^^^^^^^
+    :                                  `-- out-of-place doc comment
+ 33 |             }
+    `----
+
+  ! Line 38, char 13: Ignoring out-of-place documentation comment.
+  | Did you mean to use a multiline comment ( /* ... */ ) instead?
+    ,-[<input>:38:13]
+ 37 | 
+ 38 |             /** ORPHAN trailing in protocol body */
+    :             ^^^^^^^^^^^^^^^^^^^|^^^^^^^^^^^^^^^^^^^
+    :                                `-- out-of-place doc comment
+ 39 |         }
+    `----
+
+  ! Line 40, char 9: Ignoring out-of-place documentation comment.
+  | Did you mean to use a multiline comment ( /* ... */ ) instead?
+    ,-[<input>:40:9]
+ 39 |         }
+ 40 |         /** ORPHAN after protocol closing brace */
+    :         ^^^^^^^^^^^^^^^^^^^^^|^^^^^^^^^^^^^^^^^^^^
+    :                              `-- out-of-place doc comment
+ 41 |     
     `----


### PR DESCRIPTION
This adds a test for doc comments in all possible positions.
Everything works as expected, except for doc comments on enum variants. They are ignored (and emit a warning) because the java app ignores them and the avro schema has no place for them.
See https://avro.apache.org/docs/1.12.0/specification/#enums